### PR TITLE
Fixed error when using --script longopt

### DIFF
--- a/ps_encoder.py
+++ b/ps_encoder.py
@@ -65,7 +65,7 @@ def usage():
 
 def main():
     try:
-        options, args = getopt.getopt(sys.argv[1:], 'hs:', ['help', 'script'])
+        options, args = getopt.getopt(sys.argv[1:], 'hs:', ['help', 'script='])
     except getopt.GetoptError:
         print "Wrong Option Provided!"
         usage()


### PR DESCRIPTION
Using the --script long option resulted in the error 'The specified powershell script does not exists', due to wrong parsing of the option